### PR TITLE
ci: build docs in `release` Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,11 @@ jobs:
           pip install --constraint=.github/workflows/constraints.txt poetry
           poetry --version
 
+      - name: Install Nox
+        run: |
+          pip install --constraint=.github/workflows/constraints.txt nox nox-poetry
+          nox --version
+
       - name: Check if there is a parent commit
         id: check-parent-commit
         run: |
@@ -54,6 +59,10 @@ jobs:
       - name: Build package
         run: |
           poetry build --ansi
+
+      - name: Build docs
+        run: |
+          nox --force-color --python="3.9" --session docs
 
       - name: Publish package on PyPI
         if: steps.check-version.outputs.tag


### PR DESCRIPTION
Without building the docs, they can't be published...

See: https://github.com/NicolasT/gptsum/runs/2170793999?check_suite_focus=true#step:14:62