### PR TITLE
gptsum: fix no-argument CLI invocation

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -67,6 +67,7 @@ def mypy(session: Session) -> None:
     session.install(
         "mypy",
         "pytest",
+        "pytest-mock",
     )
     session.run("mypy", *args)
     if not session.posargs:
@@ -81,6 +82,7 @@ def tests(session: Session) -> None:
         "coverage[toml]",
         "pygments",
         "pytest",
+        "pytest-mock",
     )
     try:
         session.run("coverage", "run", "--parallel", "-m", "pytest", *session.posargs)
@@ -114,6 +116,7 @@ def typeguard(session: Session) -> None:
     session.install(
         "pygments",
         "pytest",
+        "pytest-mock",
         "typeguard",
     )
     session.run("pytest", f"--typeguard-packages={PACKAGE}", *session.posargs)

--- a/poetry.lock
+++ b/poetry.lock
@@ -641,6 +641,20 @@ toml = "*"
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
+name = "pytest-mock"
+version = "3.5.1"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+pytest = ">=5.0"
+
+[package.extras]
+dev = ["pre-commit", "tox", "pytest-asyncio"]
+
+[[package]]
 name = "pytz"
 version = "2021.1"
 description = "World timezone definitions, modern and historical"
@@ -965,7 +979,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.1"
-content-hash = "6958e95f5290482c0849e68072aaef5412ce6d1e1c21796e87e87b2aee64e80f"
+content-hash = "68a494d206d7525aa064b96c589f18116ce54de85fab73effcaa7a94f7f8e9d7"
 
 [metadata.files]
 alabaster = [
@@ -1311,6 +1325,10 @@ pyparsing = [
 pytest = [
     {file = "pytest-6.2.2-py3-none-any.whl", hash = "sha256:b574b57423e818210672e07ca1fa90aaf194a4f63f3ab909a2c67ebb22913839"},
     {file = "pytest-6.2.2.tar.gz", hash = "sha256:9d1edf9e7d0b84d72ea3dbcdfd22b35fb543a5e8f2a60092dd578936bf63d7f9"},
+]
+pytest-mock = [
+    {file = "pytest-mock-3.5.1.tar.gz", hash = "sha256:a1e2aba6af9560d313c642dae7e00a2a12b022b80301d9d7fc8ec6858e1dd9fc"},
+    {file = "pytest_mock-3.5.1-py3-none-any.whl", hash = "sha256:379b391cfad22422ea2e252bdfc008edd08509029bcde3c25b2c0bd741e0424e"},
 ]
 pytz = [
     {file = "pytz-2021.1-py2.py3-none-any.whl", hash = "sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ flake8-builtins = "^1.5.3"
 flake8-isort = "^4.0.0"
 flake8-return = "^1.1.2"
 flake8-expression-complexity = "^0.0.9"
+pytest-mock = "^3.5.1"
 
 [tool.coverage.paths]
 source = ["src", "*/site-packages"]

--- a/src/gptsum/__main__.py
+++ b/src/gptsum/__main__.py
@@ -2,8 +2,7 @@
 
 Simply invokes :func:`gptsum.cli.main`.
 """
-
 import gptsum.cli
 
 if __name__ == "__main__":
-    gptsum.cli.main()  # pragma: no cover
+    gptsum.cli.main()

--- a/src/gptsum/cli.py
+++ b/src/gptsum/cli.py
@@ -158,4 +158,8 @@ def main(args: Optional[List[str]] = None) -> None:
     parser = build_parser()
     ns = parser.parse_args(args)
 
-    ns.func(ns)
+    func = getattr(ns, "func", None)
+    if func:
+        func(ns)
+    else:
+        parser.print_usage()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,14 @@ from gptsum import checksum, cli
 from tests import conftest
 
 
+def test_no_arguments(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test the CLI without any options."""
+    cli.main([])
+
+    captured = capsys.readouterr()
+    assert captured.out.startswith("usage: ")
+
+
 def test_version(capsys: pytest.CaptureFixture[str]) -> None:
     """Test the CLI :option:`--verbose` option."""
     with pytest.raises(SystemExit):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,15 @@
 """Fake test module so :mod:`gptsum.__main__` gets imported."""
 
-import gptsum.__main__  # noqa: F401
+import runpy
+import sys
+
+from pytest_mock import MockerFixture
+
+
+def test_main(mocker: MockerFixture) -> None:
+    """Test running the :mod:`gptsum` package."""
+    mocker.patch("sys.argv", sys.argv[:1])
+    # Once for real
+    runpy.run_module("gptsum", run_name="__main__", alter_sys=True)
+    # Once to please the coverage checks
+    runpy.run_module("gptsum", alter_sys=True)


### PR DESCRIPTION
Turns out a bug was introduced when running `gptsum` without any
arguments (in which case no `func` is set on the `Namespace`).
Properly testing `gptsum.__main__` made this clear.