### PR TITLE
chore(deps-dev): align `types-dataclasses` Python version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -952,6 +952,14 @@ doc = ["sphinx-rtd-theme", "sphinx-autodoc-typehints (>=1.2.0)"]
 test = ["pytest", "typing-extensions", "mypy"]
 
 [[package]]
+name = "types-dataclasses"
+version = "0.1.5"
+description = "Typing stubs for dataclasses"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "typing-extensions"
 version = "3.7.4.3"
 description = "Backported and Experimental Type Hints for Python 3.5+"
@@ -1007,7 +1015,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.1"
-content-hash = "1714c2c74677fc8ab3a056126a9349b1907f9eed9758afbbdc3b61e3a5832055"
+content-hash = "2551115229383d66508c3b7ad3d92e62277c721d0f315753d002eccfb7d49d69"
 
 [metadata.files]
 alabaster = [
@@ -1551,6 +1559,10 @@ typed-ast = [
 typeguard = [
     {file = "typeguard-2.12.1-py3-none-any.whl", hash = "sha256:cc15ef2704c9909ef9c80e19c62fb8468c01f75aad12f651922acf4dbe822e02"},
     {file = "typeguard-2.12.1.tar.gz", hash = "sha256:c2af8b9bdd7657f4bd27b45336e7930171aead796711bc4cfc99b4731bb9d051"},
+]
+types-dataclasses = [
+    {file = "types-dataclasses-0.1.5.tar.gz", hash = "sha256:7b5f4099fb21c209f2df3a83c2b64308c29955769d610a457244dc0eebe1cafc"},
+    {file = "types_dataclasses-0.1.5-py2.py3-none-any.whl", hash = "sha256:c19491cfb981bff9cafd9c113c291a7a54adccc6298ded8ca3de0d7abe211984"},
 ]
 typing-extensions = [
     {file = "typing_extensions-3.7.4.3-py2-none-any.whl", hash = "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ flake8-return = "^1.1.3"
 flake8-expression-complexity = "^0.0.9"
 pytest-mock = "^3.6.1"
 pytest-benchmark = "^3.4.1"
-types-dataclasses = {version = "^0.1.3", python = "3.6"}
+types-dataclasses = {version = "^0.1.3", python = "< 3.7"}
 
 [tool.coverage.paths]
 source = ["src", "*/site-packages"]


### PR DESCRIPTION
Since we require `dataclasses` for `python < 3.7`, it makes sense to
have the same restriction on `types-dataclasses`, instead of using
`python = 3.6`. The net result may be the same (we require Python >= 3.6
anyway), but for consistency sake the change makes sense.