### PR TITLE
ci: add Actions to automate Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,43 @@
+---
+name: Dependabot
+
+"on":
+  pull_request_target:
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  dependabot-automerge:
+    runs-on: "ubuntu-latest"
+    if: "${{ github.actor == 'dependabot[bot]' }}"
+    steps:
+      - name: Fetch Dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@v1.1.1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: "${{ github.event.pull_request.html_url }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+  dependabot-approve:
+    runs-on: "ubuntu-latest"
+    if: "${{ github.actor == 'dependabot[bot]' }}"
+    steps:
+      - name: Fetch Dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@v1.1.1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Approve Dependabot PRs for patch version changes
+        if: "${{ steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch' }}"
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: "${{ github.event.pull_request.html_url }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This commit adds a simple workflow to trigger some actions when
Dependabot creates PRs:

- All Dependabot PRs will have "auto-merge" enabled automatically
- When Dependabot wants to update a patch version of a dependency, this
  will be automatically approved.

As such, for patch version updates, assuming all status checks pass
(i.e., tests succeed), the related PR will be merged without any human
interaction.

For minor or major version bumps, a human review/approval is still
required.

See: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/automating-dependabot-with-github-actions
See: https://github.com/dependabot/fetch-metadata/tree/ffa0846490b6178282839adcc9f50954b247e373#enabling-auto-merge
See: https://github.com/dependabot/fetch-metadata/tree/ffa0846490b6178282839adcc9f50954b247e373#auto-approving