### PR TITLE
release: gptsum 0.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "gptsum"
-version = "0.0.10"
+version = "0.1.0"
 description = "A tool to make disk images using GPT partitions self-verifiable"
 authors = [
     "Nicolas Trangez <ikke@nicolast.be>",
@@ -15,7 +15,7 @@ homepage = "https://github.com/NicolasT/gptsum"
 repository = "https://github.com/NicolasT/gptsum.git"
 keywords = ["gpt", "diskimage", "checksum"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Environment :: Console",
     "Intended Audience :: Developers",
     "Intended Audience :: Information Technology",


### PR DESCRIPTION
Support for Python 3.10 warrants a new release. Also, bumping the
`Development Status` classifier from `3 - Alpha` to `4 - Beta` since
this tool should be quite stable, hence bumping minor to `0.1`.