### PR TITLE
ci: let Dependabot manage all Python dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,5 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+    allow:
+      - dependency-type: "all"


### PR DESCRIPTION
Configure Dependabot not to only manage top-level dependencies, but also
indirect ones.

See: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#allow