### PR TITLE
tests: increase coverage on all Python versions

### DIFF
--- a/src/gptsum/checksum.py
+++ b/src/gptsum/checksum.py
@@ -8,13 +8,14 @@ from typing import Callable, List, Union, cast
 from gptsum import gpt
 
 ZERO_GUID = uuid.UUID(bytes=b"\0" * 16)
+_BUFFSIZE = 128 * 1024
 
 
 def hash_file(
     fn: Callable[[Union[bytes, memoryview]], None], fd: int, size: int, offset: int
 ) -> int:
     """Repeatedly call a function on a slice of a file."""
-    buffsize = 128 * 1024
+    buffsize = _BUFFSIZE
     done = 0
 
     os.posix_fadvise(


### PR DESCRIPTION
Given this change, both the `os.preadv`-backed implementation of
`gptsum.checksum.hash_file` as well as the `os.pread`-backed version are
covered by the test-suite. This means that, in a sufficiently recent
Python environment (>= 3.7), the code is now almost 100% covered by the
test-suite: only the import of `importlib_metadata` (or
`importlib.metadata`) isn't fully covered: either one or the other is
chosen based on the Python version (the former for Python <= 3.7, the
latter when using Python >= 3.8).