### PR TITLE
gptsum: fix call to `os.posix_fadvise`

### DIFF
--- a/src/gptsum/checksum.py
+++ b/src/gptsum/checksum.py
@@ -18,9 +18,7 @@ def hash_file(
     buffsize = _BUFFSIZE
     done = 0
 
-    os.posix_fadvise(
-        fd, offset, size, os.POSIX_FADV_SEQUENTIAL | os.POSIX_FADV_WILLNEED
-    )
+    os.posix_fadvise(fd, offset, size, os.POSIX_FADV_SEQUENTIAL)
 
     if hasattr(os, "preadv"):  # pragma: py-lt-37
         preadv = cast(


### PR DESCRIPTION
The `advice` argument passed to `os.posix_fadvise` was set to
`os.POSIX_FADV_SEQUENTIAL | os.POSIX_FADV_WILLNEED`, under the
assumption `advice` is a set of flags. Upon further inspection, it turns
out this is not the case, and `advice` is treated as a plain integer,
hence, only a single advice can be passed.

This didn't trigger exceptions, by accident, because
`POSIX_FADV_SEQUENTIAL` equals 2 on a Linux system, and
`POSIX_FADV_WILLNEED` is 3, hence the value passed to `fadvise64` was 3
(`010 | 011 == 011`).

Since the 'main' advice we want to pass to the kernel is about
sequential access, use `os.POSIX_FADV_SEQUENTIAL` only.