### PR TITLE
ci: constrain `pip` to `<22`

### DIFF
--- a/.github/workflows/constraints.in
+++ b/.github/workflows/constraints.in
@@ -1,4 +1,6 @@
-pip>=21.3.1
+# pip 22.0.0 dropped support for Python 3.6
+# See https://github.com/pypa/pip/blob/ec8edbf5df977bb88e1c777dd44e26664d81e216/NEWS.rst#deprecations-and-removals-1
+pip>=21.3.1,<22
 poetry>=1.1.12
 nox>=2022.1.7
 # nox-poetry 0.9 dropped support for Python 3.6


### PR DESCRIPTION
`pip` 22.0.0 dropped support for Python 3.6.

See: https://github.com/pypa/pip/blob/ec8edbf5df977bb88e1c777dd44e26664d81e216/NEWS.rst#deprecations-and-removals-1