### PR TITLE
Revert "chore(deps): bump dependabot/fetch-metadata from 1.3.1 to 1.3.2"

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: dependabot-metadata
-        uses: dependabot/fetch-metadata@v1.3.2
+        uses: dependabot/fetch-metadata@v1.3.1
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
@@ -31,7 +31,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: dependabot-metadata
-        uses: dependabot/fetch-metadata@v1.3.2
+        uses: dependabot/fetch-metadata@v1.3.1
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 


### PR DESCRIPTION
It appears there's an issue with version 1.3.2 of the
`dependabot/fetch-metadata` action, causing the
`Dependabot/dependabot-automerge` and `Dependabot/dependabot-approve`
jobs to fail:

```
Download action repository 'dependabot/fetch-metadata@v1.3.2'
(SHA:90ed90dba204fdf8970c1f891b4349c96353f220)
Error: dependabot/fetch-metadata/v1.3.2/action.yml:
Error: dependabot/fetch-metadata/v1.3.2/action.yml: (Line: 18, Col: 113,
Idx: 682) - (Line: 18, Col: 141, Idx: 710): While parsing a block
mapping, did not find expected key.
Error: System.ArgumentException: Unexpected type '' encountered while
reading 'action manifest root'. The type 'MappingToken' was expected.
   at
   GitHub.DistributedTask.ObjectTemplating.Tokens.TemplateTokenExtensions.AssertMapping(TemplateToken
   value, String objectDescription)
      at
      GitHub.Runner.Worker.ActionManifestManager.Load(IExecutionContext
      executionContext, String manifestFile)
      Error: Fail to load dependabot/fetch-metadata/v1.3.2/action.yml
```

Oddly enough, this wasn't caught when #372, bumping the version of the
action, was merged, since in the CI run of this PR the old version
(1.3.1) was still used.

So, rolling back to version 1.3.1 of the upstream action.

This reverts commit 3a9cd54d9ef211ab837520a53febd3b00622bd4d.

See: https://github.com/NicolasT/gptsum/runs/7146363828?check_suite_focus=true#step:1:26
See: #372
See: https://github.com/NicolasT/gptsum/pull/372
See: https://github.com/NicolasT/gptsum/runs/7146259460?check_suite_focus=true#step:1:25