### PR TITLE
ci: run Python 3.6 tests on Ubuntu 20.04

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   tests:
     name: "${{ matrix.session }} ${{ matrix.python-version }}"
-    runs-on: "ubuntu-latest"
+    runs-on: "${{ matrix.runs-on || 'ubuntu-latest' }}"
     strategy:
       fail-fast: false
       matrix:
@@ -22,12 +22,12 @@ jobs:
           - { python-version: "3.9", session: "mypy" }
           - { python-version: "3.8", session: "mypy" }
           - { python-version: "3.7", session: "mypy" }
-          - { python-version: "3.6", session: "mypy" }
+          - { python-version: "3.6", session: "mypy", runs-on: "ubuntu-20.04" }
           - { python-version: "3.10", session: "tests" }
           - { python-version: "3.9", session: "tests" }
           - { python-version: "3.8", session: "tests" }
           - { python-version: "3.7", session: "tests" }
-          - { python-version: "3.6", session: "tests" }
+          - { python-version: "3.6", session: "tests", runs-on: "ubuntu-20.04" }
           - { python-version: "3.10", session: "typeguard" }
           - { python-version: "3.10", session: "xdoctest" }
           - { python-version: "3.10", session: "docs" }


### PR DESCRIPTION
This fixes the following error on GitHub Actions:
```
Run actions/setup-python@v4
  with:
    python-version: 3.6
    check-latest: false
    token: ***
    update-environment: true
  env:
    NOXSESSION: mypy
Version 3.6 was not found in the local cache
Error: Version 3.6 with arch x64 not found
The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```

See: https://github.com/actions/setup-python/issues/544