### PR TITLE
Revert unintentional merges of dependency update PRs

### DIFF
--- a/.github/workflows/constraints.in
+++ b/.github/workflows/constraints.in
@@ -5,7 +5,7 @@ poetry>=1.1.12
 nox>=2022.1.7
 # nox-poetry 0.9 dropped support for Python 3.6
 # See https://github.com/cjolowicz/nox-poetry/releases/tag/v0.9.0
-nox-poetry<1.1
+nox-poetry<0.9
 
 # Indirect dependencies which require constraints
 # platformdirs 2.4.1 dropped support for Python 3.6

--- a/.github/workflows/constraints.in
+++ b/.github/workflows/constraints.in
@@ -10,7 +10,7 @@ nox-poetry<1.1
 # Indirect dependencies which require constraints
 # platformdirs 2.4.1 dropped support for Python 3.6
 # See https://github.com/platformdirs/platformdirs/releases/tag/2.4.1
-platformdirs<2.5.5
+platformdirs<2.4.1
 # filelock 3.4.2 dropped support for Python 3.6
 # See https://github.com/tox-dev/py-filelock/releases/tag/3.4.2
 filelock<3.4.2

--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -50,7 +50,7 @@ lockfile==0.12.2
     # via cachecontrol
 msgpack==1.0.3
     # via cachecontrol
-nox==2022.11.21
+nox==2022.1.7
     # via
     #   -r constraints.in
     #   nox-poetry
@@ -77,6 +77,8 @@ poetry-core==1.0.7
     # via poetry
 ptyprocess==0.7.0
     # via pexpect
+py==1.11.0
+    # via nox
 pycparser==2.21
     # via cffi
 pylev==1.4.0

--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -67,7 +67,7 @@ pexpect==4.8.0
     # via poetry
 pkginfo==1.8.2
     # via poetry
-platformdirs==2.5.4
+platformdirs==2.4.0
     # via
     #   -r constraints.in
     #   virtualenv

--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -54,7 +54,7 @@ nox==2022.1.7
     # via
     #   -r constraints.in
     #   nox-poetry
-nox-poetry==1.0.2
+nox-poetry==0.8.6
     # via -r constraints.in
 packaging==20.9
     # via

--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -1,0 +1,5 @@
+---
+security:
+  ignore-vulnerabilities:
+    51457:
+      reason: SVN isn't used by this project

--- a/poetry.lock
+++ b/poetry.lock
@@ -108,15 +108,20 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "chardet"
+version = "4.0.0"
+description = "Universal encoding detector for Python 2 and 3"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
 name = "charset-normalizer"
-version = "2.0.12"
+version = "3.0.0"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 category = "dev"
 optional = false
-python-versions = ">=3.5.0"
-
-[package.extras]
-unicode-backport = ["unicodedata2"]
+python-versions = "*"
 
 [[package]]
 name = "click"
@@ -406,11 +411,11 @@ gitdb = ">=4.0.1,<5"
 
 [[package]]
 name = "idna"
-version = "3.4"
+version = "2.10"
 description = "Internationalized Domain Names in Applications (IDNA)"
 category = "dev"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "imagesize"
@@ -697,21 +702,21 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "requests"
-version = "2.27.1"
+version = "2.25.1"
 description = "Python HTTP for Humans."
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.dependencies]
 certifi = ">=2017.4.17"
-charset-normalizer = {version = ">=2.0.0,<2.1.0", markers = "python_version >= \"3\""}
-idna = {version = ">=2.5,<4", markers = "python_version >= \"3\""}
+chardet = ">=3.0.2,<5"
+idna = ">=2.5,<3"
 urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
+security = ["cryptography (>=1.3.4)", "pyOpenSSL (>=0.14)"]
 socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
-use-chardet-on-py3 = ["chardet (>=3.0.2,<5)"]
 
 [[package]]
 name = "restructuredtext-lint"
@@ -1062,9 +1067,99 @@ certifi = [
     {file = "certifi-2022.9.24-py3-none-any.whl", hash = "sha256:90c1a32f1d68f940488354e36370f6cca89f0f106db09518524c88d6ed83f382"},
     {file = "certifi-2022.9.24.tar.gz", hash = "sha256:0d9c601124e5a6ba9712dbc60d9c53c21e34f5f641fe83002317394311bdce14"},
 ]
+chardet = [
+    {file = "chardet-4.0.0-py2.py3-none-any.whl", hash = "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"},
+    {file = "chardet-4.0.0.tar.gz", hash = "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa"},
+]
 charset-normalizer = [
-    {file = "charset-normalizer-2.0.12.tar.gz", hash = "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597"},
-    {file = "charset_normalizer-2.0.12-py3-none-any.whl", hash = "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"},
+    {file = "charset-normalizer-3.0.0.tar.gz", hash = "sha256:b27d10ad15740b45fd55f76e6901a4391e6dca3917ef48ecdcf17edf6e00d770"},
+    {file = "charset_normalizer-3.0.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:9b6ff2db806fc6b7dbb620a4ac77e15db9af50dcd076c03291bd039c0f8a5b78"},
+    {file = "charset_normalizer-3.0.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3eedc8e77f6f7e29a14dc5965298fd2c99f38f84ad6d85e9a7db04877268c9aa"},
+    {file = "charset_normalizer-3.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ef5272935e1c06c83c4fa2cff5deae8be71fd78443bade120314e3009ce9e7b2"},
+    {file = "charset_normalizer-3.0.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8fb6e9b463da6a3d5670ac98544c785d7a8d3ff7dc0e7916b1f51749cc3991dd"},
+    {file = "charset_normalizer-3.0.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ff5cf1e500a0da22f385691a1680a78d5e53506aadc374d722c645de6449f7f0"},
+    {file = "charset_normalizer-3.0.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8197d8a3d62dc6dfe00eb6a501588e67bcf926fb62ab5a844ae2d62d75255842"},
+    {file = "charset_normalizer-3.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:30441e51539803457d4cad07771b616354c3b0fe2213e13f3185b09ea9fb62b9"},
+    {file = "charset_normalizer-3.0.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5817dc5798902d9894d741b8200ed07cf9798c7c8f7cdcc0d8daf2a59d37607c"},
+    {file = "charset_normalizer-3.0.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:eafaf6923a5d746e4e1cfd7e52968103194df733cfc67569ee87022c0868330c"},
+    {file = "charset_normalizer-3.0.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:54d401d65073e4da58679610c7e778a16a1dca2c774a70f19653359b2d0360e1"},
+    {file = "charset_normalizer-3.0.0-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:5e4c6561d4421bdfe8ffebe5859bbfc72ce7ee0fe19401769a15e7ea8862bb90"},
+    {file = "charset_normalizer-3.0.0-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:34d9985ab611346cc248a865e3374fe183783012c9e94f39cee2156ad58cbeb8"},
+    {file = "charset_normalizer-3.0.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:bd37f952efb7d9c4ea2baf02354b69008d7f03f1ce0e519a9e002e295b80cb7d"},
+    {file = "charset_normalizer-3.0.0-cp310-cp310-win32.whl", hash = "sha256:5d339255add00bee7c7bf8390593320862414e06ac3f4984afacf3d3b85b4b87"},
+    {file = "charset_normalizer-3.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:2e2004cf0c213fb45501c2e306b1446d383ac1503251f1c1ab8796022fa374dc"},
+    {file = "charset_normalizer-3.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:5ec17dcd027ba3954c9b3d7ade5d17caba8f4f5fb74cdffce389c8d677094902"},
+    {file = "charset_normalizer-3.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:688d676e8478d699ee866e5d284e025180652729492940686f34998914445c4a"},
+    {file = "charset_normalizer-3.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9072d3abd225ef12445885ec3787054ca72472b4a2929aa03bffc97babdef7c3"},
+    {file = "charset_normalizer-3.0.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8a8d16f152229aacda89da0fc7daf9f61dd3415099a7e2505705d101eff367a8"},
+    {file = "charset_normalizer-3.0.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:910c9d2b3dfca1de0b30f99f1850337f4ba892fbf4fbf8567059600d99b8be44"},
+    {file = "charset_normalizer-3.0.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c0edc013d946e97b8202c4d7eff0dd5f9fab3c6b3a37452035cc1a0c36cdda57"},
+    {file = "charset_normalizer-3.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:85ac88100f3b97943718530192778cd726faa4cbbd51808637e09ba92eab69e3"},
+    {file = "charset_normalizer-3.0.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1cd73ed3c0851d79907d20c10898d8510e265ee8154137aa5321ca970a5db1a6"},
+    {file = "charset_normalizer-3.0.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ae52eff0673125e8efe024ccd63e783cb19966bb9211eade5e66ce03dc5b31f9"},
+    {file = "charset_normalizer-3.0.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:a7777a5d438f59205f09c2145a21b532b9c7a2c7264d07b443eda79700864efa"},
+    {file = "charset_normalizer-3.0.0-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:a1862819ec5cb7d0e183dbd2e8cb66987c180315b602e886a908f4528431ae32"},
+    {file = "charset_normalizer-3.0.0-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:399e593bda905041112b22f88c01b111fcda6fbcb6da4e421a64e67215f3dd47"},
+    {file = "charset_normalizer-3.0.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:394f3c3b376bfea5ba0c0148aa92c1d67a10d0dc377ddbbb36bdad852b1e9ef1"},
+    {file = "charset_normalizer-3.0.0-cp311-cp311-win32.whl", hash = "sha256:bdfc37b1bc0b2441a183c596d9ecc9c2bfd0536c82f809f983e1b400499da19d"},
+    {file = "charset_normalizer-3.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:c513ec3a3e1a863b5bfe2036936171cb2488dc86c84c1a2134389adbf3a82378"},
+    {file = "charset_normalizer-3.0.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:53fd5583acf63924c16c4c587aeb1996c499deecd7cc7fae697bacf825d989ac"},
+    {file = "charset_normalizer-3.0.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3631e242dcba061ca212953e7c634a55d0cdef90a37beccc087667f2fe181c36"},
+    {file = "charset_normalizer-3.0.0-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aa1814fbfb30774fba6cf052f9ca567949c514f368351a6ac6e921fabd3ba111"},
+    {file = "charset_normalizer-3.0.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e18ed76200e834740ff5a2572f563063ad33c28167a3da918f2f9706f5c49d6"},
+    {file = "charset_normalizer-3.0.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7552ee5f4383420ba2ffe902889e7bb4fd83bfcb864f48f24fb85fc52c0cd6f8"},
+    {file = "charset_normalizer-3.0.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:42dbfb26a2f5090c42551155143ac241e793c92ae7392463a7d5272c6a9bbbb6"},
+    {file = "charset_normalizer-3.0.0-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:e38ca0c6d954f6a4dde4f23a1b6b42ce8d6975e9749d3eb8a52c65f4479a033e"},
+    {file = "charset_normalizer-3.0.0-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:675558adde2c4aa96b6c3c00a81aac0d179676a52612df4cef3fcd50c90ed0d6"},
+    {file = "charset_normalizer-3.0.0-cp36-cp36m-musllinux_1_1_ppc64le.whl", hash = "sha256:47bbc5f5ca95d00f9bc92c265f298484c76f90804d2e9213ca72c763b08b1e9d"},
+    {file = "charset_normalizer-3.0.0-cp36-cp36m-musllinux_1_1_s390x.whl", hash = "sha256:39948b9ed2eb6cb2703c6c7a5db0a384fd04d5b3afa41e13b7b95aa5db79aaea"},
+    {file = "charset_normalizer-3.0.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:67ee779048055abf1dd6ce17807f7506adb206b815a58ddf2cccdc0bd58ef773"},
+    {file = "charset_normalizer-3.0.0-cp36-cp36m-win32.whl", hash = "sha256:5f94cf41de87f56ab6ffd49679a43539654c8ea28e2d93e92c987a94ad35d7d3"},
+    {file = "charset_normalizer-3.0.0-cp36-cp36m-win_amd64.whl", hash = "sha256:95881ab4c3824686518b4eefde33e24fc58b6cddd7d25e67573fef7f58a87c27"},
+    {file = "charset_normalizer-3.0.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b80d6a70d4732689df66d2b5c2af69ccbc340138151fdaff2f09b6dd3d93a786"},
+    {file = "charset_normalizer-3.0.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e43a046dca4960485ab459bb3a574f53267618b6632868567eca707dcd746f76"},
+    {file = "charset_normalizer-3.0.0-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:574eb7f491502710f99817aef59d35b7871995053075ee58af79f4564549ea98"},
+    {file = "charset_normalizer-3.0.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6d338a1d326fe22dc5ee38db23c84fe22a9c41d120c808f2b0f1f4c44959e282"},
+    {file = "charset_normalizer-3.0.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:071ed7370a7dc971f9f9075ac5a57472efcef291f9be54b4678a2fef5a179ab7"},
+    {file = "charset_normalizer-3.0.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9e106db7b184b47c47e06e557b77ea1c165bf71b8c314d32ea4feeec75dfc476"},
+    {file = "charset_normalizer-3.0.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:3f57d3835f4ad56ce0934d8d99e90052632ae65984366e8232dbe59677fe8e3f"},
+    {file = "charset_normalizer-3.0.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:7ad45ff3b056bfb014539d30bf0c4b96e9393ee84ce5263059eb54308c17a726"},
+    {file = "charset_normalizer-3.0.0-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:e75952e1c2b3e8ca14d8a9729a8f927de337bfde1b54cb9ecb2f852fe1d4bfed"},
+    {file = "charset_normalizer-3.0.0-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:47170e7ff67894aa21440af1915586e6e5d69bdbefda12ddff5058ddb53bfe6d"},
+    {file = "charset_normalizer-3.0.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:635aa7e252f62bc1e90760ad0e78ca6898a7b1c82c747168e3ca0fe694c66047"},
+    {file = "charset_normalizer-3.0.0-cp37-cp37m-win32.whl", hash = "sha256:6594af711ddf797283480fc676539e9c194a893b6b4a4b505b3651f6032d9e0c"},
+    {file = "charset_normalizer-3.0.0-cp37-cp37m-win_amd64.whl", hash = "sha256:60c40da508f037b1d12d803eed18494f07ad67f8150c7ff0e747924758d28bc9"},
+    {file = "charset_normalizer-3.0.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:0d46a5c078e6cf7562ce59b08d604b04537bdc8ea12788c1208438816413990b"},
+    {file = "charset_normalizer-3.0.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:4fa1b62a5e42e79e206838521e66c991a99d3ea7ee73dd3f213414e68208366f"},
+    {file = "charset_normalizer-3.0.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:2e31a1f162363af64e62c392e7d1e372494ac9f0c0d357c8c5ace423c7a8319b"},
+    {file = "charset_normalizer-3.0.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0231484661763fbd7c4bc44bc5082575b6d352855112ec9595ef1031058b8e81"},
+    {file = "charset_normalizer-3.0.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2c71dd29ffbbad0dc2172232d6bf4e603904af6d63ca567103c081236481c340"},
+    {file = "charset_normalizer-3.0.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3f088255848d6048df9c152fa3f05ba9559c8fceab96715cb7dc10c36080241e"},
+    {file = "charset_normalizer-3.0.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f810dc652bda19caf9ee2427325c73f5983ca4e014aaabcfb9983cb452863812"},
+    {file = "charset_normalizer-3.0.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:48fb1a491f537bb881d791d3c03e59442d0eaecab5111249e101dc099cfeae06"},
+    {file = "charset_normalizer-3.0.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:d61088b74a5af4103216cd0b61c7e4edd14396abb56fafe32a299b4fca48d095"},
+    {file = "charset_normalizer-3.0.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:4001e6f68098699d283030dff861694f4874891942103be21c3ce3c46ad453f2"},
+    {file = "charset_normalizer-3.0.0-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:727c3d2960e3ff46b71ca564383c14c3c2a1d534def7856f5c776e95f445c50e"},
+    {file = "charset_normalizer-3.0.0-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:b8cc867bf4203c5417d0c606046194a8f08f46e5c6738247f0c20aade6f7ebf7"},
+    {file = "charset_normalizer-3.0.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:8d73af825942f22de7a199eb14b1660163d19a9c584c4aaafb5abe4f72efa645"},
+    {file = "charset_normalizer-3.0.0-cp38-cp38-win32.whl", hash = "sha256:04cf77c532b0b26856f85a4a0b277dab6abc59dbd292a89df2ddb09bc4b959a8"},
+    {file = "charset_normalizer-3.0.0-cp38-cp38-win_amd64.whl", hash = "sha256:f16c77bc135afdfc1a1630725c2d4733e7f9b25d8e47382d6f4314a1a517a4f9"},
+    {file = "charset_normalizer-3.0.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:d263002ee1a8f6f08181cea6fb43951d0e05a2d26a5713b05e5229acd7f750e3"},
+    {file = "charset_normalizer-3.0.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:002d63b53c1a498b7eb326194cc294f44ce266a17a97430fca6767688af52655"},
+    {file = "charset_normalizer-3.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ed89b715b15c38d6bec7a9ba19cb57e765729981f210fbfc620402f4614c633e"},
+    {file = "charset_normalizer-3.0.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4038ebd2754390a9938e66dc43a2670a0a228532ef80e7980be8f47ed075d2b8"},
+    {file = "charset_normalizer-3.0.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0b3e5f49e3d5aa0776cdc7fb400363c94669059fccf8166e27477fe5deb9529b"},
+    {file = "charset_normalizer-3.0.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6667079603d57c7eb6af6c8a4dfde97e7d0caade188d166ee22afe5c7f2e0595"},
+    {file = "charset_normalizer-3.0.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec2ad05026efe2722222466eb5b8f1434fd4e2225ddd0d4a520261eade8986e6"},
+    {file = "charset_normalizer-3.0.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1d532e52c8ade7eac02c66f0ad21d45e794ac80ca3eed53eedb68757f8e24a1a"},
+    {file = "charset_normalizer-3.0.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:37231579ec53c103cc669a00bcb915397e7322c78523bc64dbcb3cc31fbf85bb"},
+    {file = "charset_normalizer-3.0.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:38e6aa4c45bbd6c226af124052cbd29f01e4b9b723723c2b4d4ac3ef2eb12247"},
+    {file = "charset_normalizer-3.0.0-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:2687b0593661002d06af7193edf04d0890a945c59a9b4ddbf3b1bb3b965db339"},
+    {file = "charset_normalizer-3.0.0-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:b5a4d3f1b2b43d2872a5b18ce72584f11452d797fcf08cb5aeff57069d5b830c"},
+    {file = "charset_normalizer-3.0.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a29ebfbc07cdb1c9ebb26ae213c293202da141e315224253785f7b1daa01efce"},
+    {file = "charset_normalizer-3.0.0-cp39-cp39-win32.whl", hash = "sha256:59a5949997e205e24af5bc6857f8179bb758b960255830a966bb77db4dbb5380"},
+    {file = "charset_normalizer-3.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:a5cfea2063c76867e43cf42ce6b0297f73142907a95fc28f26a992a17dcd77a1"},
+    {file = "charset_normalizer-3.0.0-py3-none-any.whl", hash = "sha256:c2a896d961d1e2a035b10f85c71ea49e3837ff79e3d30d6d3304a12172019566"},
 ]
 click = [
     {file = "click-8.0.4-py3-none-any.whl", hash = "sha256:6a7a62563bbfabfda3a38f3023a1db4a35978c0abd76f6c9605ecd6554d6d9b1"},
@@ -1206,8 +1301,8 @@ gitpython = [
     {file = "GitPython-3.1.20.tar.gz", hash = "sha256:df0e072a200703a65387b0cfdf0466e3bab729c0458cf6b7349d0e9877636519"},
 ]
 idna = [
-    {file = "idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
-    {file = "idna-3.4.tar.gz", hash = "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4"},
+    {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
+    {file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"},
 ]
 imagesize = [
     {file = "imagesize-1.4.1-py2.py3-none-any.whl", hash = "sha256:0d8d18d08f840c19d0ee7ca1fd82490fdc3729b7ac93f49870406ddde8ef8d8b"},
@@ -1440,8 +1535,8 @@ pyyaml = [
     {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
 ]
 requests = [
-    {file = "requests-2.27.1-py2.py3-none-any.whl", hash = "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"},
-    {file = "requests-2.27.1.tar.gz", hash = "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"},
+    {file = "requests-2.25.1-py2.py3-none-any.whl", hash = "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"},
+    {file = "requests-2.25.1.tar.gz", hash = "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804"},
 ]
 restructuredtext-lint = [
     {file = "restructuredtext_lint-1.4.0.tar.gz", hash = "sha256:1b235c0c922341ab6c530390892eb9e92f90b9b75046063e047cacfb0f050c45"},


### PR DESCRIPTION
Due to some temporary changes in the project configuration, a couple of @dependabot PRs were merged, even though corresponding CI jobs failed (due to Python 3.6 incompatibility).

This PR reverts these merges to restore CI success, and includes a patch to let `safety` ignore a vulnerability notification on the `py` package which doesn't actually affect this project.