### PR TITLE
release: gptsum 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "gptsum"
-version = "0.1.0"
+version = "0.2.0"
 description = "A tool to make disk images using GPT partitions self-verifiable"
 authors = [
     "Nicolas Trangez <ikke@nicolast.be>",


### PR DESCRIPTION
Support for Python 3.11 and dropping support for Python 3.6 warrants a new release.

See: https://github.com/NicolasT/gptsum/pull/571
See: https://github.com/NicolasT/gptsum/pull/559