### PR TITLE
ci: ignore `safety` #70612

### DIFF
--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -3,3 +3,5 @@ security:
   ignore-vulnerabilities:
     51457:
       reason: SVN isn't used by this project
+    70612:
+      reason: Agree with `jinja2` maintainers, we shouldn't (and aren't) rendering random templates


### PR DESCRIPTION
This package doesn't directly use `jinja2`, and doesn't render any templates. This (dubious) safety issue, hence, doesn't affect this package.