### PR TITLE
release: gptsum 0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "gptsum"
-version = "0.3.0"
+version = "0.4.0"
 description = "A tool to make disk images using GPT partitions self-verifiable"
 authors = [
     "Nicolas Trangez <ikke@nicolast.be>",


### PR DESCRIPTION
Dropping support for Python 3.7 and adding support for Python 3.12 warrants a new release.