### PR TITLE
release: gptsum 0.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "gptsum"
-version = "0.4.0"
+version = "0.4.1"
 description = "A tool to make disk images using GPT partitions self-verifiable"
 authors = [
     "Nicolas Trangez <ikke@nicolast.be>",


### PR DESCRIPTION
The previous release failed. Recovering...

This is, code-wise, identical to the `0.4.0` tag.