### PR TITLE
deps-dev: disallow `docutils-0.21`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,8 @@ pytest-mock = "^3.14.0"
 pytest-benchmark = "^4.0.0"
 coverage-conditional-plugin = "^0.9.0"
 pylint = "^3.2.7"
+# Work-around https://github.com/pypi/warehouse/issues/15749
+docutils = "!=0.21"
 
 [tool.coverage.paths]
 source = ["src", "*/site-packages"]


### PR DESCRIPTION
This version causes some issues with Poetry/Dependabot.

See: https://github.com/python-poetry/poetry/issues/9293
See: https://github.com/pypi/warehouse/issues/15749
See: https://github.com/apache/iceberg-python/pull/615