### PR TITLE
release: gptsum 0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "gptsum"
-version = "0.4.1"
+version = "0.5.0"
 description = "A tool to make disk images using GPT partitions self-verifiable"
 authors = [
     "Nicolas Trangez <ikke@nicolast.be>",


### PR DESCRIPTION
Add support for Python 3.13, and some (supposedly API-compatible) changes to the `ContextManager` ABC being used.