### PR TITLE
gptsum: drop support for Python 3.8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,6 @@ jobs:
           - { python-version: "3.11", session: "pylint" }
           - { python-version: "3.10", session: "pylint" }
           - { python-version: "3.9", session: "pylint" }
-          - { python-version: "3.8", session: "pylint" }
           - { python-version: "3.13", session: "mypy" }
           - { python-version: "3.13", session: "mypy", runs-on: "macos-15" }
           - { python-version: "3.13", session: "mypy", runs-on: "windows-2022" }
@@ -35,7 +34,6 @@ jobs:
           - { python-version: "3.11", session: "mypy" }
           - { python-version: "3.10", session: "mypy" }
           - { python-version: "3.9", session: "mypy" }
-          - { python-version: "3.8", session: "mypy" }
           - { python-version: "3.13", session: "tests" }
           - { python-version: "3.13", session: "tests", runs-on: "macos-15" }
           - { python-version: "3.13", session: "tests", runs-on: "windows-2022" }
@@ -43,7 +41,6 @@ jobs:
           - { python-version: "3.11", session: "tests" }
           - { python-version: "3.10", session: "tests" }
           - { python-version: "3.9", session: "tests" }
-          - { python-version: "3.8", session: "tests" }
           - { python-version: "3.13", session: "typeguard" }
           - { python-version: "3.13", session: "typeguard", runs-on: "macos-15" }
           - { python-version: "3.13", session: "typeguard", runs-on: "windows-2022" }

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -35,7 +35,7 @@ Request features on the `Issue Tracker`_.
 
 How to set up your development environment
 ------------------------------------------
-You need Python 3.8+ and the following tools:
+You need Python 3.9+ and the following tools:
 
 - Poetry_
 - Nox_

--- a/README.rst
+++ b/README.rst
@@ -128,7 +128,7 @@ Verifying an image file is roughly the same procedure:
 
 Implementation Details
 **********************
-`gptsum` is implemented in Python, and compatible with Python 3.8 and later.
+`gptsum` is implemented in Python, and compatible with Python 3.9 and later.
 It uses the `Blake2b`_ checksum algorithm to construct a 16 byte digest
 of the disk image.
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -18,7 +18,6 @@ PACKAGE = "gptsum"
 
 PYTHON_VERSIONS = [
     # Note: keep these sorted
-    "3.8",
     "3.9",
     "3.10",
     "3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -57,7 +56,7 @@ Issues = "https://github.com/NicolasT/gptsum/issues"
 gptsum = "gptsum.cli:main"
 
 [tool.poetry.dependencies]
-python = "^3.8.17"
+python = "^3.9.23"
 
 [tool.poetry.dev-dependencies]
 mypy = "^1.14"


### PR DESCRIPTION
Python 3.8 is no longer a supported version, and dependencies start to drop support for it. Hence, require Python 3.9 or later.