### PR TITLE
ci: fix release job by installing `poetry-plugin-export`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,9 +35,9 @@ jobs:
           pip install --constraint=.github/workflows/constraints.txt poetry
           poetry --version
 
-      - name: Install Nox
+      - name: Install Nox, nox-poetry and poetry-plugin-export
         run: |
-          pip install --constraint=.github/workflows/constraints.txt nox nox-poetry
+          pip install --constraint=.github/workflows/constraints.txt nox nox-poetry poetry-plugin-export
           nox --version
 
       - name: Check if there is a parent commit


### PR DESCRIPTION
Since updating the versions of packages installed in CI (in 3c6e3e2e3fb), `poetry export` actually no longer works without the plugin installed. This was the case in the regular test jobs, but not (yet) in the release job.

See: 3c6e3e2e3fb1557ff4b85d0d7ae87a25478b720b
See: https://github.com/NicolasT/gptsum/pull/1667
See: https://github.com/NicolasT/gptsum/actions/runs/24602674057/job/71943853952